### PR TITLE
DEB-56 Refactor User Creation

### DIFF
--- a/backend/db/fbAuth.go
+++ b/backend/db/fbAuth.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-func InitFirebaseAuth() *auth.Client {
+func InitFirebaseApp() *firebase.App {
 
 	ctx := context.Background()
 
@@ -27,12 +27,7 @@ func InitFirebaseAuth() *auth.Client {
 		log.Fatalf("error initializing app: %v\n", err)
 	}
 
-	authClient, err := app.Auth(ctx)
-	if err != nil {
-		log.Fatalf("error getting Auth client: %v\n", err)
-	}
-
-	return authClient
+	return app
 
 }
 

--- a/backend/handlers/forms.go
+++ b/backend/handlers/forms.go
@@ -212,6 +212,7 @@ func (handler *RouteHandler) SubmitRegistration(c *gin.Context) {
 		// get tournament.CurrentTeams
 		var tournament models.Tournament
 		if err := tournamentCollection.FindOne(sessCtx, bson.M{"_id": registration.TournamentID}).Decode(&tournament); err != nil {
+			session.AbortTransaction(sessCtx)
 			return err
 		}
 
@@ -251,6 +252,7 @@ func (handler *RouteHandler) SubmitRegistration(c *gin.Context) {
 		}
 
 		if err := session.CommitTransaction(sessCtx); err != nil {
+			session.AbortTransaction(sessCtx)
 			return err
 		}
 

--- a/backend/handlers/users.go
+++ b/backend/handlers/users.go
@@ -192,6 +192,12 @@ func (handler *RouteHandler) UpdateUser(c *gin.Context) {
 
 	userID := c.Param("id")
 
+	objID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID format"})
+		return
+	}
+
 	// map, key is string, values are interfaces (empty interface implies any type)
 	// alternatively can define a struct
 	// takes data from request body
@@ -225,7 +231,7 @@ func (handler *RouteHandler) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	result, updateErr := handler.collection.UpdateOne(ctx, bson.M{"fbId": userID}, bson.M{"$set": updateData})
+	result, updateErr := handler.collection.UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": updateData})
 	if updateErr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": updateErr.Error()})
 		return

--- a/backend/handlers/users.go
+++ b/backend/handlers/users.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"server/models"
 	"time"
@@ -21,21 +22,6 @@ func (handler *RouteHandler) CreateUser(c *gin.Context) {
 	var ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// FB VALIDATION
-	// get token from context
-	tokenInterface, exists := c.Get("firebaseToken")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
-		return
-	}
-
-	// assert token type
-	firebaseToken, ok := tokenInterface.(*auth.Token)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid token data"})
-		return
-	}
-
 	// get request data
 	var user models.User
 	if err := c.BindJSON(&user); err != nil {
@@ -44,13 +30,10 @@ func (handler *RouteHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
-	firebaseUID := firebaseToken.UID
-	username := user.Username
-
-	// VALIDATION 1: Check if a user with this Firebase UID OR username already exists
+	// VALIDATION 1: Check if a user with this username or email already exists
 	existingUser := handler.collection.FindOne(ctx, bson.M{"$or": []bson.M{
-		{"firebaseUID": firebaseUID},
-		{"username": username},
+		{"username": user.Username},
+		{"email": user.Email},
 	}})
 
 	if existingUser.Err() != mongo.ErrNoDocuments {
@@ -58,21 +41,6 @@ func (handler *RouteHandler) CreateUser(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": "User already exists. Please pick a different username."})
 		return
 	}
-
-	// VALIDATION 2: verify email in body against Firebase email
-	email, ok := firebaseToken.Claims["email"].(string)
-
-	fmt.Println(email)
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "error retrieving email"})
-		return
-	}
-	if user.Email != email {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "emails do not match"})
-		return
-	}
-
-	user.FbID = firebaseUID
 
 	// FINAL VALIDATION: Validate user object against schema
 	validationErr := handler.validate.Struct(user)
@@ -82,7 +50,9 @@ func (handler *RouteHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
-	// Create user
+	// -----START TRANSACTION-----
+
+	// Create user in Mongo
 	result, insertErr := handler.collection.InsertOne(ctx, user)
 	if insertErr != nil {
 		msg := fmt.Sprint("User was not created")
@@ -91,7 +61,37 @@ func (handler *RouteHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, result)
+	// get mongo generated id for the user
+	mongoObjectId, ok := result.InsertedID.(primitive.ObjectID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve valid MongoDB ObjectID"})
+		log.Println("InsertedID is not a primitive.ObjectID")
+		return
+	}
+	mongoStringId := mongoObjectId.Hex() // Convert ObjectID to string
+
+	// Create user in Firebase
+	params := (&auth.UserToCreate{}).
+		UID(mongoStringId). // set id to the mongo id
+		Email(user.Email).
+		Password(user.Password).
+		DisplayName(user.Username).
+		EmailVerified(false)
+
+	// create Firebase User
+	_, err := handler.authClient.CreateUser(context.Background(), params)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user in Firebase"})
+		log.Fatalf("Error creating Firebase user: %v\n", err)
+		return
+	}
+
+	// -----END TRANSACTION-----
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "User created successfully",
+		"userId":  mongoStringId,
+	})
 }
 
 func (handler *RouteHandler) GetUsers(c *gin.Context) {
@@ -132,9 +132,15 @@ func (handler *RouteHandler) GetUserById(c *gin.Context) {
 	// passed in api call /users/:id
 	userID := c.Param("id")
 
+	objID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID format"})
+		return
+	}
+
 	var user models.User
 	// find user
-	if err := handler.collection.FindOne(ctx, bson.M{"fbId": userID}).Decode(&user); err != nil {
+	if err := handler.collection.FindOne(ctx, bson.M{"_id": objID}).Decode(&user); err != nil {
 
 		// handle errors
 		if err == mongo.ErrNoDocuments {

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"log"
 	"net/http"
 	"os"
 	"server/config"
@@ -36,7 +38,12 @@ func main() {
 		DBname: "debatedino",
 	}
 	client := db.DBinstance()
-	authClient := db.InitFirebaseAuth()
+	firebaseApp := db.InitFirebaseApp()
+	authClient, err := firebaseApp.Auth(context.Background())
+
+	if err != nil {
+		log.Fatalf("error getting Auth client: %v\n", err)
+	}
 
 	var validate = validator.New()
 
@@ -67,10 +74,10 @@ func main() {
 	// Users
 	// might want to add filtering options, ex. /users?name=John&institution=XYZ, can access the gin.Context with c.Query("name")
 	publicRoutes.GET("/users", userHandler.GetUsers)
+	publicRoutes.POST("/users", userHandler.CreateUser)
 	// get by id
 	protectedRoutes.GET("/users/:id", userHandler.GetUserById)
 	protectedRoutes.GET("/users/:id/tournaments", userHandler.GetUserTournaments)
-	protectedRoutes.POST("/users", userHandler.CreateUser)
 	protectedRoutes.PUT("/users/:id", userHandler.UpdateUser)
 	protectedRoutes.DELETE("/users/:id", userHandler.DeleteUser)
 

--- a/backend/models/schema.go
+++ b/backend/models/schema.go
@@ -26,7 +26,6 @@ type Tournament struct {
 
 type User struct {
 	// ID            primitive.ObjectID   `json:"_id"`
-	FbID        string               `bson:"fbId" json:"fbId"` // firebase uid (no validation for testing)
 	Name        string               `bson:"name" json:"name" validate:"required"`
 	Username    string               `bson:"username" json:"username" validate:"required"`
 	Password    string               `bson:"password" json:"password" validate:"required"`

--- a/backend/routeDocs.md
+++ b/backend/routeDocs.md
@@ -1,13 +1,20 @@
 # Documentation for Endpoints:
 
+## Authentication:
+A JWT Token must be received from Firebase, and used as a bearer token in your requests.
+
+### FOR POSTMAN REQUESTS:
+- For now, sign in on frontend and copy paste the token into Postman
+- An endpoint for testing may be implemented in the future (generates a token)
+
 ## Users:
 
 ```
-GET /users/:firebaseId
+GET /users/:id
 ```
 IMPORTANT:
-- Get users takes the Firebase Id instead of the MongoDB object id.
-- We can switch back to object id if desired. I figured Firebase is easier since we always have access to the Firebase User.
+- Get users takes the MongoDB Object id
+- As of 10/18/2024, Firebase Id is the same as MongoDB id
 
 ## Tournaments:
 

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -77,7 +77,8 @@ const UserProfile = () => {
 
       try{
         const token = await fbUser.getIdToken();
-        console.log(token);
+        console.log(fbUser.uid);
+        // console.log(token);
         const config = {
           headers: {
             Authorization: `Bearer ${token}`

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -77,7 +77,7 @@ const UserProfile = () => {
 
       try{
         const token = await fbUser.getIdToken();
-        // console.log(token);
+        console.log(token);
         const config = {
           headers: {
             Authorization: `Bearer ${token}`

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -16,6 +16,6 @@ export interface TournamentUser {
 }
 
 export interface RegisterUser extends BaseUser, TournamentUser {
-    fb_id: string | undefined,
+    // fb_id: string | undefined,
     password: string,
 }


### PR DESCRIPTION
Firebase User Id is now the same as MongoDB id. User Registration Flow was modified.

Before:
- Frontend calls Firebase signup() to create FB user
- Calls backend api to create mongodb
- Transaction is enforced by manually rolling back + deleting fb user in case of any errors creating on mongo side

Current:
- Frontend calls backend api to create user
- Backend creates Mongo user
- Backend calls firebase to create Firebase user, with mongo id as the uid
- Transaction is enforced using MongoDB sessions (auto rollback for mongo user creation)

